### PR TITLE
Fix swagger errors

### DIFF
--- a/authentication/callback/s-function.json
+++ b/authentication/callback/s-function.json
@@ -19,7 +19,9 @@
       "authorizationType": "none",
       "authorizerFunction": false,
       "apiKeyRequired": false,
-      "requestParameters": {},
+      "requestParameters": {
+        "integration.request.path.provider": "method.request.path.provider"
+      },
       "requestTemplates": {
         "application/json": "{\"provider\":\"$input.params('provider')\",\"code\":\"$input.params('code')\",\"state\":\"$input.params('state')\",\"host\":\"$input.params().header.get('host')\",\"stage\":\"$context.stage\"}"
       },

--- a/authentication/signin/s-function.json
+++ b/authentication/signin/s-function.json
@@ -19,7 +19,9 @@
       "authorizationType": "none",
       "authorizerFunction": false,
       "apiKeyRequired": false,
-      "requestParameters": {},
+      "requestParameters": {
+        "integration.request.path.provider": "method.request.path.provider"
+      },
       "requestTemplates": {
         "application/json": "{\"provider\":\"$input.params('provider')\",\"host\":\"$input.params().header.get('host')\",\"stage\":\"$context.stage\"}"
       },


### PR DESCRIPTION
When exporting a swagger file from the API gateway stage, errors are raised due to missing path parameter declarations:
![screenshot-2016-05-17_11-34-30](https://cloud.githubusercontent.com/assets/260983/15309610/57f68514-1c23-11e6-8d21-c9e7d42ee065.png)


This PR adds the definitions, translated by swagger as follow:
```
      parameters:
      - name: "provider"
        in: "path"
        required: true
        type: "string"
```