### PR TITLE
Fix error propagation for sign-in handler

### DIFF
--- a/authentication/lib/handlers/signinHandler.js
+++ b/authentication/lib/handlers/signinHandler.js
@@ -55,7 +55,7 @@ async function signinHandler(proxyEvent) {
         )
     }
   } catch (exception) {
-    data = utils.errorResponse({ exception }, providerConfig)
+    data = utils.errorResponse({ error: exception }, providerConfig)
   }
   return {
     statusCode: 302,


### PR DESCRIPTION
This makes the sign in handler propagate errors like other handlers.